### PR TITLE
Update git-authors.sed to eliminate the '+' character

### DIFF
--- a/git-authors.sed
+++ b/git-authors.sed
@@ -96,7 +96,7 @@ s/^mharder$/Michael Harder/
 s/^michael.ernst$/Michael Ernst/
 s/^minilek$/Jelani Nelson/
 s/^mjollnir$/Matt Mullen/
-+s/^naveensrinivasan$/Naveen Srinivasan/
+s/^naveensrinivasan$/Naveen Srinivasan/
 s/^nimakarimipour$/Nima Karimipour/
 s/^nitin23329$/Nitin Kumar Das/
 s/^NITIN DAS$/Nitin Kumar Das/


### PR DESCRIPTION
The extra '+' character causes errors when trying to run `make contributors.tex` on macOS.
